### PR TITLE
Create inbox options should be optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export class TempMail {
      * @param domain {string} the specific domain to use.
      * @returns {Inbox} the Inbox object with the address and token.
      */
-    async createInbox(options: CreateInboxOptions): Promise<Inbox> {
+    async createInbox(options?: CreateInboxOptions): Promise<Inbox> {
         let url = "/inbox/create";
         
         const r = await this.makeRequest(url, options);


### PR DESCRIPTION
Providing an empty JSON object `{}` resulted in this error, however it seems to work by omitting the field entirely. The types should reflect this.

<img width="1343" alt="Screenshot 2025-01-13 at 20 01 10" src="https://github.com/user-attachments/assets/22fae9ec-947c-4f42-9735-aaae758cda85" />
